### PR TITLE
Fix double-question-mark output by builder.query.

### DIFF
--- a/ClubHouse/ClubHouse.csproj
+++ b/ClubHouse/ClubHouse.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <ProductName>ClubHouse</ProductName>
     <RepositoryUrl>https://github.com/ctolkien/ClubHouse</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -15,6 +15,9 @@
     <PackageTags>clubhouse, project management, api</PackageTags>
     <PackageReleaseNotes>Version 2 - Lots of bugs fixed, minor API changes</PackageReleaseNotes>
     <PackageIconUrl>https://github.com/ctolkien/ClubHouse/raw/master/nuget-icon.png</PackageIconUrl>
+    <AssemblyVersion>2.0.2</AssemblyVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <FileVersion>2.0.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ClubHouse/ClubHouseHttpMessageHandler.cs
+++ b/ClubHouse/ClubHouseHttpMessageHandler.cs
@@ -29,7 +29,7 @@ namespace ClubHouse
             }
             else
             {
-                builder.Query = $"?token={token}";
+                builder.Query = $"token={token}";
             }
 
             request.RequestUri = builder.Uri;


### PR DESCRIPTION
Resolves this error - "Sorry, the company context for this request is missing"

